### PR TITLE
Fix bug with checking/unchecking Lege-checkbox in MeldMotebehovSkjema

### DIFF
--- a/js/utils/motebehovUtils.js
+++ b/js/utils/motebehovUtils.js
@@ -23,12 +23,13 @@ export const input2RSLagreMotebehov = (motebehov) => {
       rsMotebehovSvar.harMotebehov = motebehov.harMotebehov;
     }
   }
-  if (isDefined(motebehov.forklaring) && isDefined(motebehov.lege)) {
+  const hasChosenLege = motebehov.lege === true;
+  if (isDefined(motebehov.forklaring) && hasChosenLege) {
     const separator = ' ';
     rsMotebehovSvar.forklaring = `${MELDMOTEBEHOV_FELTER.lege.tekst}${separator}${motebehov.forklaring.trim()}`;
   } else if (isDefined(motebehov.forklaring)) {
     rsMotebehovSvar.forklaring = motebehov.forklaring.trim();
-  } else if (isDefined(motebehov.lege)) {
+  } else if (hasChosenLege) {
     rsMotebehovSvar.forklaring = MELDMOTEBEHOV_FELTER.lege.tekst;
   }
   return rsMotebehovSvar;


### PR DESCRIPTION
If the user first checks the checkbox for Lege in MeldMotebehov and the unchecks the the checkbox the text will falsely be appende inn Forklaring of MotebehovSvar. This is a bug and is fixed in this commit, ensuring that the Lege-text is only appende if the checkbox is checked.