### PR TITLE
G5qBhv62: Rename tracking for videomote

### DIFF
--- a/js/MVP/views/moteinnkallelse/components/VeilederInnkallelseContent.tsx
+++ b/js/MVP/views/moteinnkallelse/components/VeilederInnkallelseContent.tsx
@@ -19,7 +19,7 @@ const VeilederInnkallelseContent = (): ReactElement => {
       <Lenke
         href={statiskeURLer.VIDEOMOTE_INFO_URL}
         target="_blank"
-        onClick={() => trackOnClick(eventNames.lesMerOmSykefravaer)}
+        onClick={() => trackOnClick(eventNames.lesOmHvordanDeltaVideomote)}
       >
         {texts.veilederLink1}
       </Lenke>

--- a/js/amplitude/events.ts
+++ b/js/amplitude/events.ts
@@ -8,7 +8,7 @@ export const eventNames = {
   lastNedReferat: 'Klikker på last ned referat',
   lenkeIReferat: 'Klikker på info url i referat',
   lesMerOmDialogmoter: 'Klikker på les mer om dialogmøter',
-  lesMerOmSykefravaer: 'Klikker på les mer om sykefravær og dialogmøter',
+  lesOmHvordanDeltaVideomote: 'Klikker på les om hvordan delta i videomote',
   meldBehov: 'Klikker på meld behov',
   meldBehovKvittering: 'Klikker på kvittering meld behov',
   oppfolgingsplan: 'Klikker på oppfølgingsplan',


### PR DESCRIPTION
Renamer for å ha konsistens med arbeidsgiver, og mer tydelig beskrivelse av hva eventet gjør